### PR TITLE
Fixed a couple links that were not relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ The following instructions cover setup and install of the entire system.
         
 
 #### Javascript, NodeJS, and Related Libraries
-[Follow the instructions here, including submodules](https://github.com/ASAAR/SE2-KaggleComp/blob/master/modules/MLTA/README.md)
+[Follow the instructions here, including submodules](modules/MLTA/README.md)
 
 #### Test Data
-[Download and setup the test data so that unit tests run properly](https://github.com/ASAAR/SE2-KaggleComp/blob/master/datasets/README.md)
+[Download and setup the test data so that unit tests run properly](datasets/README.md)
 
 To verify correct setup, please run the tests.
 
@@ -117,7 +117,7 @@ Pending
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/ASAAR/SE2-KaggleComp/blob/documentation/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Versioning
 


### PR DESCRIPTION
There were a couple links within the repo that linked to other parts of the repo using absolute links. This is highly **not recommended** by GitHub standards.  

To those who do not know what I am talking about check out [this post](https://help.github.com/articles/relative-links-in-readmes/) by GitHub for more.