### PR TITLE
Quickfix for model in project configuration

### DIFF
--- a/modules/DMZ/project_config/model.py
+++ b/modules/DMZ/project_config/model.py
@@ -35,7 +35,7 @@ class Param(object):
         super(Param, self).__init__()
         self.details = {}
         self.values = []
-        if not root.has_key('name'):
+        if not root.attrib.has_key('name'):
             raise ModelXMLError('Required Param XML attribute [name] not found',\
             root)
         for key, value in root.items():

--- a/modules/DMZ/project_config/tests/test_configuration.py
+++ b/modules/DMZ/project_config/tests/test_configuration.py
@@ -6,7 +6,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../..'))
 from modules.DMZ.project_config.configuration import Configuration
 from modules.DMZ.project_config.configuration import ConfigurationError
 from modules.DMZ.project_config.configuration import ConfigurationXMLError
@@ -79,7 +79,7 @@ def create_attrib_models(attributes):
     If number=false, then there will be a value attribute with a list of values.
     """
     models = {}
-    for i in range(1, attributes['seed']%5):
+    for i in range(1, attributes['seed']%5 + 2):
         model = {}
         model['name'] = 'model{}'.format(i)
         model['params'] = create_attrib_params(attributes['seed']%3 + (2*i))
@@ -308,7 +308,6 @@ class TestConfigurationHappyPath(TestConfigurationBase):
         Tests that the models were correctly loaded into the
         configuration object.
         """
-        exp_attrib = self.attributes['Models']
         act_models = self.config.models
         self.assertEqual(len(exp_attrib.keys()), len(act_models.keys()))
         for exp_key, exp_model in exp_attrib.items():

--- a/modules/DMZ/project_config/tests/test_configuration.py
+++ b/modules/DMZ/project_config/tests/test_configuration.py
@@ -6,7 +6,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 
-sys.path.insert(0, os.path.abspath('../../..'))
+sys.path.insert(0, os.path.abspath('..'))
 from modules.DMZ.project_config.configuration import Configuration
 from modules.DMZ.project_config.configuration import ConfigurationError
 from modules.DMZ.project_config.configuration import ConfigurationXMLError
@@ -308,8 +308,11 @@ class TestConfigurationHappyPath(TestConfigurationBase):
         Tests that the models were correctly loaded into the
         configuration object.
         """
+        exp_attrib = self.attributes['Models']
         act_models = self.config.models
         self.assertEqual(len(exp_attrib.keys()), len(act_models.keys()))
+        self.assertNotEqual(len([]),len(act_models.keys()))
+
         for exp_key, exp_model in exp_attrib.items():
             self.assertTrue(act_models.has_key(exp_key))
             self.check_model(exp_model, act_models[exp_key])


### PR DESCRIPTION
As @ZakeryFyke recently noted: There was an element error being thrown by `model.py`. This PR fixes it. 
This PR also fixes an error in the tests that would have caught that.