### PR TITLE
fixed test_data_fillers

### DIFF
--- a/modules/DMZ/data_kit/test/test_data_fillers.py
+++ b/modules/DMZ/data_kit/test/test_data_fillers.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 
 from modules.toolbox.data_package import DataPackage
-from modules.toolbox.validation_package import ValidationPackage
 
 
 class TestDataFilling(TestCase):

--- a/modules/DMZ/data_kit/test/test_filler_strategy.py
+++ b/modules/DMZ/data_kit/test/test_filler_strategy.py
@@ -41,8 +41,8 @@ class TestFillerStrategy(TestCase):
 
         # Arrange
         self.strategy.pandas_dataset = self.data
-        self.strategy.avg_range = [0,.10]
-        self.strategy.value_range = [.10, .20]
+        self.strategy.avg_range = [.9,1]
+        self.strategy.value_range = [.0, .899]
 
         # Act
         self.strategy.get_to_do_list()

--- a/modules/DMZ/data_kit/test/test_filler_strategy.py
+++ b/modules/DMZ/data_kit/test/test_filler_strategy.py
@@ -41,10 +41,12 @@ class TestFillerStrategy(TestCase):
 
         # Arrange
         self.strategy.pandas_dataset = self.data
+        self.strategy.pandas_dataset.loc[self.data.shape[0]] = np.nan 
         self.strategy.avg_range = [.9,1]
         self.strategy.value_range = [.0, .899]
 
         # Act
+        self.strategy.get_missing_ratios_dict()
         self.strategy.get_to_do_list()
         self.strategy.run_fillers()
         self.strategy.get_missing_ratios_dict()

--- a/modules/DMZ/data_kit/test/test_text_handlers.py
+++ b/modules/DMZ/data_kit/test/test_text_handlers.py
@@ -11,7 +11,7 @@ import setup
 import pandas as pd
 from sklearn import preprocessing
 from modules.toolbox.data_package import DataPackage
-from modules.toolbox.validation_package import ValidationPackage
+
 
 
 class TestDataFilling(TestCase):


### PR DESCRIPTION
Imagine that, referencing something that doesn't exist is a no-no.
This is related to .pyc files lingering around, causing tests not to
fail.

Closes #149 